### PR TITLE
Add Sphinx Extension classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
         'Environment :: Console',
         'Environment :: Web Environment',
         'Environment :: Plugins',
+        'Framework :: Sphinx :: Extension',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',


### PR DESCRIPTION
Add the Sphinx Extension PyPi classifier so that the extension shows up in the correct [PyPi filters](https://pypi.org/search/?c=Framework+%3A%3A+Sphinx+%3A%3A+Extension).