### PR TITLE
feat: improve system message readability with structured literal blocks

### DIFF
--- a/src/sphinxnotes/lilypond/__init__.py
+++ b/src/sphinxnotes/lilypond/__init__.py
@@ -56,17 +56,20 @@ class lily_outline_node(nodes.Part, nodes.Element):
 def _make_sysmsg_node(
     summary: str,
     detail: Exception | str | None = None,
-    lilysrc: str | None = None,
-    location=None,
+    location: nodes.Node | None = None,
 ) -> nodes.system_message:
-    node = nodes.system_message(summary + '.', type='ERROR', level=2, backrefs=[], source='')
+    summary = summary + ':' if detail else '.'
+    node = nodes.system_message(
+        summary,
+        type='ERROR',
+        level=2,
+        backrefs=[],
+        source=location.source if location else None,
+        line=location.line if location else None,
+    )
     if detail:
-        node += nodes.Text('Details:')
         node += nodes.literal_block('', str(detail))
-    if lilysrc:
-        node += nodes.Text('LilyPond source:')
-        node += nodes.literal_block('', lilysrc)
-    logger.warning(f'{summary}: {detail}', location=location)
+    logger.warning(f'{summary} {detail}', location=location)
     return node
 
 
@@ -99,7 +102,8 @@ def jianpu_role(role, rawtext, text, lineno, inliner, options={}, content=[]):
             detail=e,
             location=inliner.parent,
         )
-        return [], [sm]
+        problematic = inliner.problematic(rawtext, text, sm)
+        return [problematic], [sm]
     return lily_role(role, rawtext, text, lineno, inliner, options, content)
 
 
@@ -124,17 +128,19 @@ class BaseLilyDirective(SphinxDirective):
         try:
             lilysrc = self.read_lily_source()
         except OSError as e:
+            lb = nodes.literal_block(self.block_text, self.block_text)
             sm = _make_sysmsg_node(
                 'Failed to read LilyPond source', detail=e, location=self.state.parent
             )
-            return [sm]
+            return [lb, sm]
         except jianpu.Error as e:
+            lb = nodes.literal_block(self.block_text, self.block_text)
             sm = _make_sysmsg_node(
                 'Failed to convert Jianpu source to LilyPond source',
                 detail=e,
                 location=self.state.parent,
             )
-            return [sm]
+            return [lb, sm]
 
         if not isinstance(self.env.app.builder, (StandaloneHTMLBuilder, LaTeXBuilder)):
             # Builder is not supported, fallback to literal_block.
@@ -274,10 +280,14 @@ def get_lilypond_output(
                 doc.transpose(from_pitch, to_pitch)
             out = doc.output(builddir, node.get('crop'))
         except lilypond.Error as e:
+            if isinstance(node, lily_outline_node):
+                lb = nodes.literal_block('', node['lilysrc'])
+            else:
+                lb = nodes.literal('', node['lilysrc'])
+            lb.walkabout(self)
             sm = _make_sysmsg_node(
                 'Failed to generate scores',
                 detail=e,
-                lilysrc=node['lilysrc'],
                 location=node,
             )
             sm.walkabout(self)
@@ -443,7 +453,12 @@ def parse_html_size(sz: str) -> tuple[float, str]:
 
 
 def raise_no_score_message_and_skip(self, node):
-    sm = _make_sysmsg_node('No score generated', lilysrc=node['lilysrc'], location=node)
+    if isinstance(node, lily_outline_node):
+        lb = nodes.literal_block('', node['lilysrc'])
+    else:
+        lb = nodes.literal('', node['lilysrc'])
+    lb.walkabout(self)
+    sm = _make_sysmsg_node('No score generated', location=node)
     sm.walkabout(self)
     raise nodes.SkipNode
 

--- a/src/sphinxnotes/lilypond/__init__.py
+++ b/src/sphinxnotes/lilypond/__init__.py
@@ -53,6 +53,23 @@ class lily_outline_node(nodes.Part, nodes.Element):
     pass
 
 
+def _make_sysmsg_node(
+    summary: str,
+    detail: Exception | str | None = None,
+    lilysrc: str | None = None,
+    location=None,
+) -> nodes.system_message:
+    node = nodes.system_message(summary + '.', type='ERROR', level=2, backrefs=[], source='')
+    if detail:
+        node += nodes.Text('Details:')
+        node += nodes.literal_block('', str(detail))
+    if lilysrc:
+        node += nodes.Text('LilyPond source:')
+        node += nodes.literal_block('', lilysrc)
+    logger.warning(f'{summary}: {detail}', location=location)
+    return node
+
+
 def lily_role(role, rawtext, text, lineno, inliner, options={}, content=[]):
     env = inliner.document.settings.env  # type: ignore
 
@@ -77,9 +94,11 @@ def jianpu_role(role, rawtext, text, lineno, inliner, options={}, content=[]):
     try:
         text = jianpu.to_lilypond(unescape(text, restore_backslashes=True))
     except jianpu.Error as e:
-        msg = 'failed to convert Jianpu source to LilyPond source: %s' % e
-        logger.warning(msg, location=inliner.parent)
-        sm = nodes.system_message(msg, type='WARNING', level=2, backrefs=[], source='')
+        sm = _make_sysmsg_node(
+            'Failed to convert Jianpu source to LilyPond source',
+            detail=e,
+            location=inliner.parent,
+        )
         return [], [sm]
     return lily_role(role, rawtext, text, lineno, inliner, options, content)
 
@@ -105,17 +124,15 @@ class BaseLilyDirective(SphinxDirective):
         try:
             lilysrc = self.read_lily_source()
         except OSError as e:
-            msg = 'failed to read LilyPond source: %s' % e
-            logger.warning(msg, location=self.state.parent)
-            sm = nodes.system_message(
-                msg, type='WARNING', level=2, backrefs=[], source=''
+            sm = _make_sysmsg_node(
+                'Failed to read LilyPond source', detail=e, location=self.state.parent
             )
             return [sm]
         except jianpu.Error as e:
-            msg = 'failed to convert Jianpu source to LilyPond source: %s' % e
-            logger.warning(msg, location=self.state.parent)
-            sm = nodes.system_message(
-                msg, type='WARNING', level=2, backrefs=[], source=''
+            sm = _make_sysmsg_node(
+                'Failed to convert Jianpu source to LilyPond source',
+                detail=e,
+                location=self.state.parent,
             )
             return [sm]
 
@@ -257,9 +274,11 @@ def get_lilypond_output(
                 doc.transpose(from_pitch, to_pitch)
             out = doc.output(builddir, node.get('crop'))
         except lilypond.Error as e:
-            logger.warning('failed to generate scores: %s' % e, location=node)
-            sm = nodes.system_message(
-                e, type='WARNING', level=2, backrefs=[], source=node['lilysrc']
+            sm = _make_sysmsg_node(
+                'Failed to generate scores',
+                detail=e,
+                lilysrc=node['lilysrc'],
+                location=node,
             )
             sm.walkabout(self)
             shutil.rmtree(builddir)  # cleanup lilypond builddir
@@ -424,11 +443,7 @@ def parse_html_size(sz: str) -> tuple[float, str]:
 
 
 def raise_no_score_message_and_skip(self, node):
-    msg = 'no score generated'
-    logger.warning(msg, location=node)
-    sm = nodes.system_message(
-        msg, type='WARNING', level=2, backrefs=[], source=node['lilysrc']
-    )
+    sm = _make_sysmsg_node('No score generated', lilysrc=node['lilysrc'], location=node)
     sm.walkabout(self)
     raise nodes.SkipNode
 

--- a/src/sphinxnotes/lilypond/__init__.py
+++ b/src/sphinxnotes/lilypond/__init__.py
@@ -454,9 +454,10 @@ def parse_html_size(sz: str) -> tuple[float, str]:
 
 def raise_no_score_message_and_skip(self, node):
     if isinstance(node, lily_outline_node):
-        lb = nodes.literal_block('', node['lilysrc'])
+        lb = nodes.literal_block(node['rawtext'], node['rawtext'])
     else:
-        lb = nodes.literal('', node['lilysrc'])
+        lb = nodes.literal(node['rawtext'], node['rawtext'])
+        # TODO: Move sphinxnotes-render's problematic
     lb.walkabout(self)
     sm = _make_sysmsg_node('No score generated', location=node)
     sm.walkabout(self)


### PR DESCRIPTION
## Summary

- Rewrite error/warning rendering for LilyPond scores using `literal_block` children instead of plain text in `system_message` nodes
- Create `_make_sysmsg_node()` helper that constructs structured `system_message` nodes with proper `source`/`line` attribution
- Use `inliner.problematic()` in `jianpu_role` for bidirectional ID links between problematic text and system messages
- Display LilyPond source independently from error details, leveraging builders' native `literal_block` rendering (HTML `<pre>`, LaTeX verbatim)
- Merge `logger.warning()` into `_make_sysmsg_node()` so each call site is a single line

## Changes

| Area | Before | After |
|------|--------|-------|
| `jianpu_role` | plain `system_message(msg)` | `inliner.problematic()` + structured `_make_sysmsg_node()` |
| Directives (OSError, jianpu.Error) | plain `system_message(msg)` | `[literal_block, _make_sysmsg_node()]` |
| Builder error handlers | `system_message(msg, source=lilysrc)` | `literal_block.walkabout()` + `_make_sysmsg_node()` |